### PR TITLE
Add Bitcoin Fee Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Play with trading simulators where you can engage with the market and practice y
 
 ## Other Trading Tools 
  * [Coinfarm Online](https://www.coinfarm.online/) - Provides information about long/short positions on derivative markets.
- * [BTCBench – All‑In‑One Bitcoin Fee Calculator](https://www.btcbench.com/calculator.html) - Estimate Bitcoin transaction costs, benchmark them against real‑time network data, and uncover over-payment on your wallet’s fee estimates.
+ * [BTCBench Fee Calculator](https://www.btcbench.com/calculator.html) - Estimate Bitcoin transaction costs, benchmark them against real‑time network data, and uncover over-payment on your wallet’s fee estimates.
  * [Cryptomiso](https://www.cryptomiso.com/) - Github commit history of cryptocurrencies based on most popular repo.
  * [Datamish](https://datamish.com/) - Charts for long/short positions and liquidations on Bitinex and Bitmex. 
  * [Trade aggregator](https://aggr.trade) - Significant trades aggregator.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Play with trading simulators where you can engage with the market and practice y
 
 ## Other Trading Tools 
  * [Coinfarm Online](https://www.coinfarm.online/) - Provides information about long/short positions on derivative markets.
+ * [BTCBench – All‑In‑One Bitcoin Fee Calculator](https://www.btcbench.com/calculator.html) - Estimate Bitcoin transaction costs, benchmark them against real‑time network data, and uncover over-payment on your wallet’s fee estimates.
  * [Cryptomiso](https://www.cryptomiso.com/) - Github commit history of cryptocurrencies based on most popular repo.
  * [Datamish](https://datamish.com/) - Charts for long/short positions and liquidations on Bitinex and Bitmex. 
  * [Trade aggregator](https://aggr.trade) - Significant trades aggregator.


### PR DESCRIPTION
Hi,

I just want to add All-In-One Bitcoin Fee Calculator to the Other Trading Tools section.

About All-In-One Bitcoin Fee Calculator:

* Free tool to estimate Bitcoin transaction fees (real-time)
* Benchmark them against real‑time network data
* Uncover over-payment on wallet’s fee estimates
* No signup required

Website: https://www.btcbench.com/calculator.html

Thank you for maintaining this Awesome-Crypto-Trading list!
