### PR TITLE
Add XHuntr — X community sniper for Solana traders

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Play with trading simulators where you can engage with the market and practice y
  * [Whale Alert](https://twitter.com/whale_alert) - Blockchain tracker reporting large transactions.
 
 # Coding Your Own Bots 
+ * [XHuntr](https://xhuntr.com) - X (Twitter) community sniper — Telegram bot that fires real-time alerts when tracked accounts create or join X communities, post contract addresses inside communities before tweeting publicly, or when multiple accounts converge on the same community. Social layer signal that fires 24-48h before on-chain activity.
 
 ## Trading Bots and Bot Frameworks
  * [Bowhead](https://github.com/joeldg/bowhead) - A REST-API and console-based cryptocurrency trading bot framework written in PHP.

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ Play with trading simulators where you can engage with the market and practice y
  * [Datamish](https://datamish.com/) - Charts for long/short positions and liquidations on Bitinex and Bitmex. 
  * [Trade aggregator](https://aggr.trade) - Significant trades aggregator.
  * [Whale Alert](https://twitter.com/whale_alert) - Blockchain tracker reporting large transactions.
+ * [XHuntr](https://xhuntr.com) - X (Twitter) community sniper — Telegram bot that fires real-time alerts when tracked accounts create or join X communities, post contract addresses inside communities before tweeting publicly, or when multiple accounts converge on the same community. Social layer signal that fires 24-48h before on-chain activity.
 
 # Coding Your Own Bots 
- * [XHuntr](https://xhuntr.com) - X (Twitter) community sniper — Telegram bot that fires real-time alerts when tracked accounts create or join X communities, post contract addresses inside communities before tweeting publicly, or when multiple accounts converge on the same community. Social layer signal that fires 24-48h before on-chain activity.
 
 ## Trading Bots and Bot Frameworks
  * [Bowhead](https://github.com/joeldg/bowhead) - A REST-API and console-based cryptocurrency trading bot framework written in PHP.


### PR DESCRIPTION
XHuntr (https://xhuntr.com) is a Telegram bot that monitors X (Twitter) accounts in real-time and fires instant alerts when tracked accounts create or join X communities, post Solana contract addresses inside communities before tweeting publicly, or when multiple tracked accounts converge on the same community.

It provides the social layer signal that fires 24-48h before on-chain wallet activity — complementary to the on-chain trackers already listed in this repo.

Added under **Other Trading Tools** as a social monitoring / alert tool.