### PR TITLE
Add DeepAlpha - AI crypto trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Play with trading simulators where you can engage with the market and practice y
  * [Bowhead](https://github.com/joeldg/bowhead) - A REST-API and console-based cryptocurrency trading bot framework written in PHP.
  * [Bxbot](https://github.com/gazbert/bxbot) - A simple Bitcoin trading bot written in Java. 
  * [Crypto Trading Bot](https://github.com/Haehnchen/crypto-trading-bot) - Cryptocurrency trading bot in Javascript.
+ * [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 3-model ML ensemble (XGBoost, HMM, Transformer), 70.9% walk-forward accuracy, supporting 12 exchanges.
  * [Freqtrade](https://github.com/freqtrade/freqtrade) - Crypto trading bot written in Python that features backtesting, plotting and money management tools.
  * [Gekko](https://github.com/askmike/gekko) - Gekko is a Bitcoin TA trading and backtesting platform that connects to popular Bitcoin exchanges. It is written in JavaScript and runs on Node.js.
  * [Gocryptotrader](https://github.com/thrasher-corp/gocryptotrader) - A cryptocurrency trading bot and framework supporting multiple exchanges written in Golang. 


### PR DESCRIPTION
## Adding DeepAlpha

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI crypto trading bot:

- **3-model ML ensemble** (XGBoost, HMM, Transformer) — 70.9% walk-forward accuracy
- **12 exchanges**: Bybit, Binance, OKX, Gate.io, KuCoin, Bitget, HTX, MEXC, BingX, Phemex, BitMart, WhiteBIT
- **Cloud platform** with dashboard, backtesting, TradingView webhooks
- **7-day free trial** — no credit card required
- **Open source** — PyPI: `pip install deepalpha-bot`
- **Non-custodial** — funds stay on user's exchange

Website: https://deepalphabot.com
GitHub: https://github.com/stefanoviana/deepalpha
PyPI: https://pypi.org/project/deepalpha-bot/