### PR TITLE
Add AgentServices — x402-paid crypto/market data API with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Play with trading simulators where you can engage with the market and practice y
 ## API and Datasets
 
 ### API
+ * [AgentServices](https://agentservices.to) - Crypto/market data API platform with 54 services, 97 endpoints, and x402 on-chain payments (USDC on Base). Includes MCP server with 37 tools for AI agent integration.
  * [CCXT](https://github.com/ccxt/ccxt) - A JavaScript / Python / PHP cryptocurrency trading unified API interface.
  * [CoinAPI](https://www.coinapi.io/) - Cryptocurrency data API solely focused on providing price and market data.
  * [CoinGecko](https://www.coingecko.com/en/api) - CoinGecko provides both market and non-market data such as development & social community statistics, events and on-chain metrics.


### PR DESCRIPTION
## What
Added [AgentServices](https://agentservices.to) to the **API** section under API and Datasets.

## Why
AgentServices is a crypto/market data API platform with 54 services and 97 endpoints. It uses the x402 payment protocol for per-call payments (USDC on Base), and includes an MCP server with 37 tools for AI agent integration. This makes it a natural fit alongside CCXT, CoinAPI, CoinGecko, and CryptoCompare.