### PR TITLE
Add Darkbot to Automate Your Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Play with trading simulators where you can engage with the market and practice y
 
  * [3Commas](https://3commas.io/) - Ready-to-use bots; Copy trading platform; Trailing stop-loss/take-profit orders.
  * [Cryptohopper](https://www.cryptohopper.com/) - Cryptohopper is rich in features to automate TA strategy. There's also a marketplace where you can copy other users' strategies.
+ * [Darkbot](https://darkbot.io/) - Cloud crypto trading bots with grid, DCA, and a visual strategy designer; backtesting and paper trading.
  * [HaasOnline](https://www.haasonline.com/) - HaasOnline offers quite advanced tools to automate TA strategy at a cost which does seem more like an enterprise solution.
  * [Shrimpy](https://www.shrimpy.io/) - Portfolio management tool with social trading and automated portfolio rebalancing features.  
 


### PR DESCRIPTION
Adds [Darkbot](https://darkbot.io/) under **Automate Your Trading**, in alphabetical order between Cryptohopper and HaasOnline.

Darkbot is a cloud crypto trading platform (grid, DCA, visual strategy designer, backtesting, paper trading), in the same category as 3Commas, Cryptohopper, HaasOnline, and Shrimpy.

Format follows CONTRIBUTING: `[Resource Name](link) - Short description.`